### PR TITLE
Make settlement offer taker have an optional reference

### DIFF
--- a/models/settlement/one-time-offer-implementation/daml.yaml
+++ b/models/settlement/one-time-offer-implementation/daml.yaml
@@ -3,7 +3,7 @@
 sdk-version: 2.6.3
 name: synfini-settlement-one-time-offer
 source: src
-version: 0.0.1
+version: 0.0.2
 dependencies:
   - daml-prim
   - daml-stdlib

--- a/models/settlement/one-time-offer-implementation/src/Synfini/Settlement/OneTimeOffer.daml
+++ b/models/settlement/one-time-offer-implementation/src/Synfini/Settlement/OneTimeOffer.daml
@@ -50,7 +50,7 @@ template OneTimeOffer
 
     interface instance OneTimeOffer.I for OneTimeOffer where
       view = OneTimeOffer.View with ..
-      accept OneTimeOffer.Accept { quantity, description } = do
+      accept OneTimeOffer.Accept { quantity, reference } = do
         assertMsg
           "Quantity must be greater than or equal to permitted minimum"
           (O.optional True (quantity >=) minQuantity)
@@ -67,7 +67,9 @@ template OneTimeOffer
           contextId = None
           instructors = settlementInstructors
           settlers
-          description
+          description = "Settlement generated from the following request:\n" <>
+            offerDescription <>
+            O.optional "" (\ref -> "\nReference: " <> ref) reference
           routedSteps
           settlementTime
       reject _ = pure ()

--- a/models/settlement/one-time-offer-interface/daml.yaml
+++ b/models/settlement/one-time-offer-interface/daml.yaml
@@ -3,7 +3,7 @@
 sdk-version: 2.6.3
 name: synfini-settlement-one-time-offer-interface
 source: src
-version: 0.0.1
+version: 0.0.2
 dependencies:
   - daml-prim
   - daml-stdlib

--- a/models/settlement/one-time-offer-interface/src/Synfini/Interface/Settlement/OneTimeOffer/OneTimeOffer.daml
+++ b/models/settlement/one-time-offer-interface/src/Synfini/Interface/Settlement/OneTimeOffer/OneTimeOffer.daml
@@ -62,7 +62,7 @@ interface OneTimeOffer requires Disclosure.I where
   choice Accept : (ContractId Batch.I, [ContractId Instruction.I])
     with
       quantity : Decimal -- ^ The quantity of each settlement step will be multiplied by this amount.
-      description : Text -- ^ Description of the 'Batch' which can be used to add any comments or reference information.
+      reference : Optional Text -- ^ Optional reference information provided by the taker of the offer.
     controller (view this).offeree
     do
       accept this arg

--- a/models/settlement/open-offer-implementation/daml.yaml
+++ b/models/settlement/open-offer-implementation/daml.yaml
@@ -3,7 +3,7 @@
 sdk-version: 2.6.3
 name: synfini-settlement-open-offer
 source: src
-version: 0.0.1
+version: 0.0.2
 dependencies:
   - daml-prim
   - daml-stdlib

--- a/models/settlement/open-offer-implementation/src/Synfini/Settlement/OpenOffer.daml
+++ b/models/settlement/open-offer-implementation/src/Synfini/Settlement/OpenOffer.daml
@@ -50,7 +50,7 @@ template OpenOffer
 
     interface instance OpenOffer.I for OpenOffer where
       view = OpenOffer.View with ..
-      take' OpenOffer.Take { id, taker, quantity, description } = do
+      take' OpenOffer.Take { id, taker, quantity, reference } = do
         assertMsg
           "Quantity must be greater than or equal to permitted minimum"
           (O.optional True (quantity >=) minQuantity)
@@ -81,7 +81,9 @@ template OpenOffer
           contextId = Some offerId
           instructors = Set.fromList (resolveParty <$> Set.toList settlementInstructors)
           settlers = Set.fromList (resolveParty <$> Set.toList settlers)
-          description
+          description = "Settlement generated from the following request:\n" <>
+            offerDescription <>
+            O.optional "" (\ref -> "\nReference: " <> ref) reference
           routedSteps
           settlementTime = actualSettlementTime
       revoke _ = pure ()

--- a/models/settlement/open-offer-interface/daml.yaml
+++ b/models/settlement/open-offer-interface/daml.yaml
@@ -3,7 +3,7 @@
 sdk-version: 2.6.3
 name: synfini-settlement-open-offer-interface
 source: src
-version: 0.0.1
+version: 0.0.2
 dependencies:
   - daml-prim
   - daml-stdlib

--- a/models/settlement/open-offer-interface/src/Synfini/Interface/Settlement/OpenOffer/OpenOffer.daml
+++ b/models/settlement/open-offer-interface/src/Synfini/Interface/Settlement/OpenOffer/OpenOffer.daml
@@ -79,7 +79,7 @@ interface OpenOffer requires Disclosure.I where
       id : Id -- ^ Settlement 'Batch' ID.
       taker : Party -- ^ Party taking the offer.
       quantity : Decimal -- ^ The quantity of each settlement step will be multiplied by this amount.
-      description : Text -- ^ Description of the 'Batch' which can be used to add any comments or reference information.
+      reference : Optional Text -- ^ Optional reference information provided by the taker of the offer.
     controller taker
     do
       take' this arg

--- a/operations/README.md
+++ b/operations/README.md
@@ -824,11 +824,11 @@ Contract Set to find an `OpenOffer` with matching `offerId` and `offerers`.
 
 The second argument is a comma-delimited list of the labels of the parties which authorised offer. The third argument is
 the offer ID and the fourth argument is the batch ID of the settlement instructions that will be generated. The batch
-ID should be a unique, randomly generated value. The final two arguments are the unit quantity specified and batch
-description chosen by the taker.
+ID should be a unique, randomly generated value. The final two arguments are the unit quantity specified and transaction
+reference chosen by the taker.
 
 ```bash
-dops take-settlement-open-offer <path to JSON file> <offerer1>,<offerer2>...<offererN> <offer ID> <Batch ID> <quantity> <description>
+dops take-settlement-open-offer <path to JSON file> <offerer1>,<offerer2>...<offererN> <offer ID> <Batch ID> <quantity> <reference>
 ```
 
 For example, for an offer authorised by parties labeled "alice" and "bob", having ID "offer1":

--- a/operations/main/daml.yaml
+++ b/operations/main/daml.yaml
@@ -3,7 +3,7 @@
 sdk-version: 2.6.3
 name: synfini-operations
 source: src
-version: 0.1.0
+version: 0.2.0
 dependencies:
   - daml-prim
   - daml-stdlib

--- a/operations/main/src/Synfini/Operations/Settlement/OpenOffer.daml
+++ b/operations/main/src/Synfini/Operations/Settlement/OpenOffer.daml
@@ -114,7 +114,7 @@ data TakeOpenOfferSettings = TakeOpenOfferSettings
     taker : Text
     quantity : Decimal
     id : Text
-    description : Text
+    reference : Optional Text
 
 data TakeOpenOfferInput = TakeOpenOfferInput
   with
@@ -146,5 +146,5 @@ takeOpenOffer input = do
       taker
       quantity = settings.quantity
       id = Id settings.id
-      description = settings.description
+      reference = settings.reference
   pure ()

--- a/wallet-ui/package-lock.json
+++ b/wallet-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "synfini-wallet-ui",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "synfini-wallet-ui",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "license": "ISC",
       "dependencies": {
         "@auth0/auth0-react": "^2.0.1",
@@ -21,8 +21,8 @@
         "@daml.js/synfini-issuer-onboarding-instrument-token-interface": "file:daml.js/synfini-issuer-onboarding-instrument-token-interface-0.0.1",
         "@daml.js/synfini-issuer-onboarding-minter-burner-interface": "file:daml.js/synfini-issuer-onboarding-minter-burner-interface-0.0.1",
         "@daml.js/synfini-settlement-helpers": "file:daml.js/synfini-settlement-helpers-0.0.1",
-        "@daml.js/synfini-settlement-one-time-offer-interface": "file:daml.js/synfini-settlement-one-time-offer-interface-0.0.1",
-        "@daml.js/synfini-settlement-open-offer-interface": "file:daml.js/synfini-settlement-open-offer-interface-0.0.1",
+        "@daml.js/synfini-settlement-one-time-offer-interface": "file:daml.js/synfini-settlement-one-time-offer-interface-0.0.2",
+        "@daml.js/synfini-settlement-open-offer-interface": "file:daml.js/synfini-settlement-open-offer-interface-0.0.2",
         "@daml.js/synfini-wallet-views-types": "file:../wallet-views/typescript-client/daml.js/synfini-wallet-views-types-0.0.3",
         "@daml/ledger": "2.6.3",
         "@daml/react": "2.6.3",
@@ -319,6 +319,20 @@
     "daml.js/synfini-settlement-one-time-offer-interface-0.0.1": {
       "name": "@daml.js/synfini-settlement-one-time-offer-interface-0.0.1",
       "version": "2.6.3",
+      "extraneous": true,
+      "license": "UNLICENSED",
+      "dependencies": {
+        "@daml.js/40f452260bef3f29dede136108fc08a88d5a5250310281067087da6f0baddff7": "file:../40f452260bef3f29dede136108fc08a88d5a5250310281067087da6f0baddff7",
+        "@daml.js/97b883cd8a2b7f49f90d5d39c981cf6e110cf1f1c64427a28a6d58ec88c43657": "file:../97b883cd8a2b7f49f90d5d39c981cf6e110cf1f1c64427a28a6d58ec88c43657",
+        "@daml.js/d14e08374fc7197d6a0de468c968ae8ba3aadbf9315476fd39071831f5923662": "file:../d14e08374fc7197d6a0de468c968ae8ba3aadbf9315476fd39071831f5923662",
+        "@daml.js/daml-finance-interface-settlement-2.0.0": "file:../daml-finance-interface-settlement-2.0.0",
+        "@daml.js/daml-finance-interface-types-common-1.0.1": "file:../daml-finance-interface-types-common-1.0.1",
+        "@mojotech/json-type-validation": "^3.1.0"
+      }
+    },
+    "daml.js/synfini-settlement-one-time-offer-interface-0.0.2": {
+      "name": "@daml.js/synfini-settlement-one-time-offer-interface-0.0.2",
+      "version": "2.6.3",
       "license": "UNLICENSED",
       "dependencies": {
         "@daml.js/40f452260bef3f29dede136108fc08a88d5a5250310281067087da6f0baddff7": "file:../40f452260bef3f29dede136108fc08a88d5a5250310281067087da6f0baddff7",
@@ -331,6 +345,21 @@
     },
     "daml.js/synfini-settlement-open-offer-interface-0.0.1": {
       "name": "@daml.js/synfini-settlement-open-offer-interface-0.0.1",
+      "version": "2.6.3",
+      "extraneous": true,
+      "license": "UNLICENSED",
+      "dependencies": {
+        "@daml.js/40f452260bef3f29dede136108fc08a88d5a5250310281067087da6f0baddff7": "file:../40f452260bef3f29dede136108fc08a88d5a5250310281067087da6f0baddff7",
+        "@daml.js/733e38d36a2759688a4b2c4cec69d48e7b55ecc8dedc8067b815926c917a182a": "file:../733e38d36a2759688a4b2c4cec69d48e7b55ecc8dedc8067b815926c917a182a",
+        "@daml.js/97b883cd8a2b7f49f90d5d39c981cf6e110cf1f1c64427a28a6d58ec88c43657": "file:../97b883cd8a2b7f49f90d5d39c981cf6e110cf1f1c64427a28a6d58ec88c43657",
+        "@daml.js/d14e08374fc7197d6a0de468c968ae8ba3aadbf9315476fd39071831f5923662": "file:../d14e08374fc7197d6a0de468c968ae8ba3aadbf9315476fd39071831f5923662",
+        "@daml.js/daml-finance-interface-settlement-2.0.0": "file:../daml-finance-interface-settlement-2.0.0",
+        "@daml.js/daml-finance-interface-types-common-1.0.1": "file:../daml-finance-interface-types-common-1.0.1",
+        "@mojotech/json-type-validation": "^3.1.0"
+      }
+    },
+    "daml.js/synfini-settlement-open-offer-interface-0.0.2": {
+      "name": "@daml.js/synfini-settlement-open-offer-interface-0.0.2",
       "version": "2.6.3",
       "license": "UNLICENSED",
       "dependencies": {
@@ -2392,11 +2421,11 @@
       "link": true
     },
     "node_modules/@daml.js/synfini-settlement-one-time-offer-interface": {
-      "resolved": "daml.js/synfini-settlement-one-time-offer-interface-0.0.1",
+      "resolved": "daml.js/synfini-settlement-one-time-offer-interface-0.0.2",
       "link": true
     },
     "node_modules/@daml.js/synfini-settlement-open-offer-interface": {
-      "resolved": "daml.js/synfini-settlement-open-offer-interface-0.0.1",
+      "resolved": "daml.js/synfini-settlement-open-offer-interface-0.0.2",
       "link": true
     },
     "node_modules/@daml.js/synfini-wallet-views-types": {
@@ -23816,7 +23845,7 @@
       }
     },
     "@daml.js/synfini-settlement-one-time-offer-interface": {
-      "version": "file:daml.js/synfini-settlement-one-time-offer-interface-0.0.1",
+      "version": "file:daml.js/synfini-settlement-one-time-offer-interface-0.0.2",
       "requires": {
         "@daml.js/40f452260bef3f29dede136108fc08a88d5a5250310281067087da6f0baddff7": "file:../40f452260bef3f29dede136108fc08a88d5a5250310281067087da6f0baddff7",
         "@daml.js/97b883cd8a2b7f49f90d5d39c981cf6e110cf1f1c64427a28a6d58ec88c43657": "file:../97b883cd8a2b7f49f90d5d39c981cf6e110cf1f1c64427a28a6d58ec88c43657",
@@ -23827,7 +23856,7 @@
       }
     },
     "@daml.js/synfini-settlement-open-offer-interface": {
-      "version": "file:daml.js/synfini-settlement-open-offer-interface-0.0.1",
+      "version": "file:daml.js/synfini-settlement-open-offer-interface-0.0.2",
       "requires": {
         "@daml.js/40f452260bef3f29dede136108fc08a88d5a5250310281067087da6f0baddff7": "file:../40f452260bef3f29dede136108fc08a88d5a5250310281067087da6f0baddff7",
         "@daml.js/733e38d36a2759688a4b2c4cec69d48e7b55ecc8dedc8067b815926c917a182a": "file:../733e38d36a2759688a4b2c4cec69d48e7b55ecc8dedc8067b815926c917a182a",

--- a/wallet-ui/package.json
+++ b/wallet-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "synfini-wallet-ui",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "",
   "private": true,
   "scripts": {
@@ -28,8 +28,8 @@
     "@daml.js/synfini-issuer-onboarding-instrument-token-interface": "file:daml.js/synfini-issuer-onboarding-instrument-token-interface-0.0.1",
     "@daml.js/synfini-issuer-onboarding-minter-burner-interface": "file:daml.js/synfini-issuer-onboarding-minter-burner-interface-0.0.1",
     "@daml.js/synfini-settlement-helpers": "file:daml.js/synfini-settlement-helpers-0.0.1",
-    "@daml.js/synfini-settlement-one-time-offer-interface": "file:daml.js/synfini-settlement-one-time-offer-interface-0.0.1",
-    "@daml.js/synfini-settlement-open-offer-interface": "file:daml.js/synfini-settlement-open-offer-interface-0.0.1",
+    "@daml.js/synfini-settlement-one-time-offer-interface": "file:daml.js/synfini-settlement-one-time-offer-interface-0.0.2",
+    "@daml.js/synfini-settlement-open-offer-interface": "file:daml.js/synfini-settlement-open-offer-interface-0.0.2",
     "@daml.js/synfini-wallet-views-types": "file:../wallet-views/typescript-client/daml.js/synfini-wallet-views-types-0.0.3",
     "@daml/ledger": "2.6.3",
     "@daml/react": "2.6.3",

--- a/wallet-ui/src/components/layout/accountsSelect.tsx
+++ b/wallet-ui/src/components/layout/accountsSelect.tsx
@@ -12,9 +12,9 @@ export default function AccountsSelect(props: AccountsSelectProps) {
         {props.accounts !== undefined && (
           <select name="accountSelect" onChange={props.onChange} value={props.selectedAccount}>
               <option value="" defaultValue="">Select one account</option>
-            {props.accounts.map(account => (
+            {props.accounts.map(account =>
               <option value={`${account.view.custodian}@${account.view.id.unpack}`} key={account.cid}>{account.view.description}</option>
-            ))}
+            )}
           </select>
         )}
       </div>

--- a/wallet-ui/src/components/layout/offerDetails.tsx
+++ b/wallet-ui/src/components/layout/offerDetails.tsx
@@ -2,19 +2,18 @@ import { useNavigate } from "react-router-dom";
 import HoverPopUp from "./hoverPopUp";
 import { CreateEvent } from "@daml/ledger";
 import { OneTimeOffer } from "@daml.js/synfini-settlement-one-time-offer-interface/lib/Synfini/Interface/Settlement/OneTimeOffer/OneTimeOffer";
+import { setToArray } from "../../Util";
 
-interface IssuerDetailsProps {
+interface OfferDetailsProps {
   offer: CreateEvent<OneTimeOffer, undefined, string>;
 }
 
-export default function OfferDetails(props: IssuerDetailsProps) {
+export default function OfferDetails(props: OfferDetailsProps) {
   const nav = useNavigate();
 
   const handleClickOfferID = () => {
     nav("/offer/accept", { state: { offer: props.offer } });
   };
-
-  const offerersArray = props.offer.payload.offerers.map.entriesArray().map(kv => kv[0]);
 
   return (
     <>
@@ -26,7 +25,7 @@ export default function OfferDetails(props: IssuerDetailsProps) {
             </a>
           </td>
           <td>
-            {offerersArray.map(offerer => (
+            {setToArray(props.offer.payload.offerers).map(offerer => (
               <div key={offerer}>
                 <HoverPopUp triggerText={offerer.substring(0, 40) + "..."} popUpContent={offerer} /> <br />
               </div>

--- a/wallet-ui/src/components/layout/settlementDetails.tsx
+++ b/wallet-ui/src/components/layout/settlementDetails.tsx
@@ -110,7 +110,7 @@ export default function SettlementDetails(props: SettlementDetailsProps) {
             <br />
           </div>
           <Field>Description:</Field>
-          {props.settlement.description}
+            <span style={{whiteSpace: "pre-wrap"}}>{props.settlement.description}</span>
           <br />
           <Field>Transaction Status:</Field>
           {props.settlement.execution === null ? (
@@ -131,9 +131,9 @@ export default function SettlementDetails(props: SettlementDetailsProps) {
         </div>
 
         <hr></hr>
-        {props.settlement.steps.map((step: SettlementStep, index: number) => (
-          <div key={index}>
-            <h5 className="profile__title">Step {index + 1}</h5>
+        {props.settlement.steps.map((step: SettlementStep) => (
+          <div key={step.instructionId.unpack}>
+            <h5 className="profile__title">Instruction ID: {step.instructionId.unpack}</h5>
             <div style={{ margin: "15px" }}>
               <Field>Type: </Field>
               {
@@ -527,11 +527,11 @@ export function SettlementDetailsAction(props: SettlementDetailsProps) {
           </div>
 
           <hr></hr>
-          {primaryParty === undefined || props.settlement.steps.map((step: SettlementStep, index: number) => {
+          {primaryParty === undefined || props.settlement.steps.map((step: SettlementStep) => {
             return (
               <>
-                <div key={index}>
-                  <h5 className="profile__title">Step {index + 1}</h5>
+                <div key={step.instructionId.unpack}>
+                  <h5 className="profile__title">Instruction ID: {step.instructionId.unpack}</h5>
                   <div style={{ margin: "15px" }}>
                     <div
                       style={{

--- a/wallet-ui/src/pages/BalanceRedeemFormScreen.tsx
+++ b/wallet-ui/src/pages/BalanceRedeemFormScreen.tsx
@@ -54,7 +54,7 @@ const BalanceRedeemFormScreen: React.FC = () => {
           offersByIssuer[0].contractId,
           {
             id: { unpack: referenceIdUUID },
-            description: "Redeem for fiat",
+            reference: null,
             taker: primaryParty,
             quantity: amountInput
           }

--- a/wallet-ui/src/pages/FundSubscribeFormScreen.tsx
+++ b/wallet-ui/src/pages/FundSubscribeFormScreen.tsx
@@ -71,7 +71,7 @@ export const FundSubscribeFormScreen: React.FC = () => {
           id: { unpack: referenceIdUUID },
           taker: primaryParty,
           quantity: inputQtd.toString(),
-          description: "Investment request"
+          reference: null
         }
       );
       setReferenceId(referenceIdUUID);

--- a/wallet-ui/src/pages/OfferAcceptFormScreen.tsx
+++ b/wallet-ui/src/pages/OfferAcceptFormScreen.tsx
@@ -22,7 +22,7 @@ export const OfferAcceptFormScreen: React.FC = () => {
 
   const ledger = userContext.useLedger();
   const { primaryParty } = useWalletUser();
-  const [transactionRefInput, setTransactionRefInput] = useState("");
+  const [transactionRefInput, setTransactionRefInput] = useState<string | null>(null);
   const defaultQuantity = state.offer.payload.minQuantity || "1";
   const [quantityInput, setQuantityInput] = useState(defaultQuantity);
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
@@ -67,7 +67,7 @@ export const OfferAcceptFormScreen: React.FC = () => {
         state.offer.contractId,
         {
           quantity: quantityInput,
-          description: transactionRefInput,
+          reference: transactionRefInput,
         }
       );
       setAccepted(true);
@@ -139,59 +139,60 @@ export const OfferAcceptFormScreen: React.FC = () => {
       <DivBorderRoundContainer style={{ height: "auto" }}>
         <form onSubmit={handleSubmit}>
           <table className="request">
-            <tr>
-              <th>ID:</th>
-              <td>{state.offer.payload.offerId.unpack}</td>
-            </tr>
-            <tr>
-              <th>Description:</th>
-              <td>{state.offer.payload.offerDescription}</td>
-            </tr>
-            <tr>
-              <th>Requested by:</th>
-              <td>{setToArray(state.offer.payload.offerers).map(party => <>{party}<br/></>)}</td>
-            </tr>
-            <tr>
-              <th>Receivable:</th>
-              <td>{stepElements(false)}</td>
-            </tr>
-            <tr>
-              <th>Deliverable:</th>
-              <td>{stepElements(true)}</td>
-            </tr>
-            {
-              !fixedAmount && isOfferee &&
+            <tbody>
               <tr>
-                <th>Select amount:</th>
-                <td>
-                  <input
-                    type="number"
-                    name="quantity"
-                    style={{ width: "100px" }}
-                    onChange={handleQuantityInput}
-                    required
-                    min={state.offer.payload.minQuantity || "0"}
-                    max={state.offer.payload.maxQuantity || undefined}
-                    defaultValue={defaultQuantity}
-                  />
-                </td>
+                <th>ID:</th>
+                <td>{state.offer.payload.offerId.unpack}</td>
               </tr>
-            }
-            {
-              isOfferee &&
               <tr>
-                <th>Reference:</th>
-                <td>
-                  <input
-                    type="text"
-                    name="transactionRef"
-                    style={{ width: "300px" }}
-                    onChange={handleTransactionRef}
-                    required
-                  />
-                </td>
+                <th>Description:</th>
+                <td>{state.offer.payload.offerDescription}</td>
               </tr>
-            }
+              <tr>
+                <th>Requested by:</th>
+                <td>{setToArray(state.offer.payload.offerers).map(party => <div key={party}>{party}<br/></div>)}</td>
+              </tr>
+              <tr>
+                <th>Receivable:</th>
+                <td>{stepElements(false)}</td>
+              </tr>
+              <tr>
+                <th>Deliverable:</th>
+                <td>{stepElements(true)}</td>
+              </tr>
+              {
+                !fixedAmount && isOfferee &&
+                <tr>
+                  <th>Select amount:</th>
+                  <td>
+                    <input
+                      type="number"
+                      name="quantity"
+                      style={{ width: "100px" }}
+                      onChange={handleQuantityInput}
+                      required
+                      min={state.offer.payload.minQuantity || "0"}
+                      max={state.offer.payload.maxQuantity || undefined}
+                      defaultValue={defaultQuantity}
+                    />
+                  </td>
+                </tr>
+              }
+              {
+                isOfferee &&
+                <tr>
+                  <th>Reference:</th>
+                  <td>
+                    <input
+                      type="text"
+                      name="transactionRef"
+                      style={{ width: "300px" }}
+                      onChange={handleTransactionRef}
+                    />
+                  </td>
+                </tr>
+              }
+            </tbody>
           </table>
           {
             isOfferee &&


### PR DESCRIPTION
Previously settlement offer takers could choose the `Batch` description but this caused problems in the UI as we lost any description of the offer from which the settlement was generated. Instead, the taker now has an optional reference field they can use to insert any information they need to. 

Fixes https://github.com/SynfiniDLT/daml-tokenization-lib/issues/51

Also removes use of instruction indexes in the settlement screens, instead we use instruction IDs which are guaranteed to be the same for all viewers of the settlement.